### PR TITLE
fix: add prepublishOnly guard to run tests before npm publish

### DIFF
--- a/packages/ol/package.json
+++ b/packages/ol/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "test": "bun test",
+    "prepublishOnly": "bun test",
     "bump": "npm version prerelease --preid=beta --workspaces=false && npm publish --tag beta",
     "patch": "npm version patch --workspaces=false && npm publish --tag latest"
   }


### PR DESCRIPTION
## Problem

Currently `bump` and `patch` scripts execute `npm publish` directly without any pre-publish validation:

```json
"bump": "npm version prerelease --preid=beta --workspaces=false && npm publish --tag beta",
"patch": "npm version patch --workspaces=false && npm publish --tag latest"
```

If tests happen to be failing at the time of publish, a broken package can still be released to npm. This is easy to miss especially when iterating quickly during beta.

## Solution

Add a `prepublishOnly` lifecycle hook that runs `bun test` before every `npm publish`:

```json
"prepublishOnly": "bun test"
```

[`prepublishOnly`](https://docs.npmjs.com/cli/v10/using-npm/scripts#life-cycle-scripts) is an npm lifecycle script that runs automatically **before** `npm publish` and **before** `npm pack`. If tests fail, the publish is aborted — no manual step needed.

## What changes

- `packages/ol/package.json`: Added `"prepublishOnly": "bun test"` to scripts

## How it works

```
npm publish
  └─ prepublishOnly (bun test)
       ├─ tests pass → publish proceeds ✅
       └─ tests fail → publish aborted ❌
```

Both `bump` and `patch` scripts will now be guarded automatically since they both call `npm publish` internally.

## Testing

Verified locally:
- `npm publish --dry-run` triggers `prepublishOnly` and runs `bun test` as expected
- If a test is intentionally broken, publish is correctly aborted

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `prepublishOnly` to run `bun test` before every `npm publish`, so publishes abort if tests fail. This guards both `bump` and `patch` flows in `packages/ol` to prevent broken releases.

<sup>Written for commit c2bda75fb1428902e5d2aaf6b184fad9624194cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

