### PR TITLE
fix: support non-tty bun script execution in openlogs

### DIFF
--- a/packages/ol/src/cli.test.ts
+++ b/packages/ol/src/cli.test.ts
@@ -193,6 +193,39 @@ test("cli works when launched from a tty", async () => {
   expect(await Bun.file(join(outDir, "latest.txt")).text()).toBe("tty\n");
 });
 
+test("cli can run bun scripts that include --elide-lines in non-tty mode", async () => {
+  const projectDir = join(outDir, "fixture-project");
+  await mkdir(projectDir, { recursive: true });
+  await Bun.write(
+    join(projectDir, "package.json"),
+    JSON.stringify(
+      {
+        name: "fixture-project",
+        private: true,
+        scripts: {
+          "dev:desktop":
+            'python3 -c "import sys; sys.stdout.write(\'desktop-ok\\\\n\')" --elide-lines=0',
+        },
+      },
+      null,
+      2
+    )
+  );
+
+  const proc = Bun.spawn(
+    ["bun", cliPath, "--out-dir", outDir, "bun", "dev:desktop"],
+    {
+      cwd: projectDir,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    }
+  );
+
+  expect(await proc.exited).toBe(0);
+  expect(await Bun.file(join(outDir, "latest.txt")).text()).toContain("desktop-ok\n");
+});
+
 test("cli tail prints the latest text log", async () => {
   await mkdir(outDir, { recursive: true });
   await Bun.write(join(outDir, "latest.txt"), "one\ntwo\nthree\n");

--- a/packages/ol/src/cli.ts
+++ b/packages/ol/src/cli.ts
@@ -2,8 +2,9 @@
 
 /* global Bun */
 
-import { createWriteStream } from "node:fs";
+import { createWriteStream, existsSync, readFileSync } from "node:fs";
 import { access, appendFile, mkdir, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import process from "node:process";
 import { finished } from "node:stream/promises";
 import {
@@ -50,9 +51,9 @@ def snapshot_descendants():
     while stack:
         current = stack.pop()
         for descendant in children.get(current, []):
-          if descendant not in tracked:
-              tracked.add(descendant)
-              stack.append(descendant)
+            if descendant not in tracked:
+                tracked.add(descendant)
+                stack.append(descendant)
 
 def living_pids():
     pids = [child.pid, *tracked]
@@ -128,9 +129,11 @@ async function main() {
   }
 
   const { options } = parsed;
-  const paths = getLogPaths(options);
-  const run = getRunRecord(options, paths);
-  await mkdir(options.outDir, { recursive: true });
+  const command = normalizeCommandForEnvironment(options.command);
+  const normalizedOptions = { ...options, command };
+  const paths = getLogPaths(normalizedOptions);
+  const run = getRunRecord(normalizedOptions, paths);
+  await mkdir(normalizedOptions.outDir, { recursive: true });
   await Promise.all(
     [
       ...new Set([paths.captureRawPath, ...paths.rawPaths, ...paths.textPaths]),
@@ -142,36 +145,40 @@ async function main() {
   const rawStreams = paths.rawPaths.map((path) => createWriteStream(path));
   const textStreams = paths.textPaths.map((path) => createWriteStream(path));
   const decoder = new TextDecoder();
+  const writeChunk = (chunk: Uint8Array) => {
+    process.stdout.write(chunk);
+    captureStream.write(chunk);
+    for (const stream of rawStreams) {
+      stream.write(chunk);
+    }
+    const cleaned = cleanChunk(chunk, decoder);
+    if (cleaned) {
+      for (const stream of textStreams) {
+        stream.write(cleaned);
+      }
+    }
+  };
   const proc = Bun.spawn(
-    ["python3", "-c", supervisionScript, ...options.command],
+    ["python3", "-c", supervisionScript, ...normalizedOptions.command],
     {
-      terminal: {
-        cols: process.stdout.columns ?? 80,
-        rows: process.stdout.rows ?? 24,
-        data(_, data) {
-          process.stdout.write(data);
-          captureStream.write(data);
-          for (const stream of rawStreams) {
-            stream.write(data);
-          }
-          const cleaned = cleanChunk(data, decoder);
-          if (cleaned) {
-            for (const stream of textStreams) {
-              stream.write(cleaned);
-            }
-          }
-        },
-      },
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
     }
   );
-  const teardown = setupTerminalHandlers(proc);
+  const teardown = setupProcessHandlers(proc);
+  const outputPump = Promise.all([
+    pumpProcessOutput(proc.stdout, writeChunk),
+    pumpProcessOutput(proc.stderr, writeChunk),
+  ]);
 
-  if (options.printPaths) {
+  if (normalizedOptions.printPaths) {
     printPaths(paths.rawPaths, paths.textPaths);
   }
 
   try {
-    return await proc.exited;
+    const [exitCode] = await Promise.all([proc.exited, outputPump]);
+    return exitCode;
   } finally {
     const flushed = flushCleanText(decoder);
     if (flushed) {
@@ -227,12 +234,7 @@ async function resolveTailPath(options: TailOptions) {
   );
 }
 
-function setupTerminalHandlers(proc: Bun.Subprocess) {
-  const { terminal } = proc;
-  if (!terminal) {
-    throw new Error("Failed to create PTY terminal.");
-  }
-
+function setupProcessHandlers(proc: Bun.Subprocess) {
   let rawModeEnabled = false;
   const onInput = (data: Buffer) => {
     if (hasInterruptByte(data)) {
@@ -241,11 +243,7 @@ function setupTerminalHandlers(proc: Bun.Subprocess) {
       }
       return;
     }
-
-    terminal.write(data);
-  };
-  const onResize = () => {
-    terminal.resize(process.stdout.columns ?? 80, process.stdout.rows ?? 24);
+    proc.stdin?.write(data);
   };
   const signalHandlers = ["SIGINT", "SIGTERM", "SIGHUP"].map((signal) => {
     const handler = () => {
@@ -264,12 +262,11 @@ function setupTerminalHandlers(proc: Bun.Subprocess) {
 
   process.stdin.resume();
   process.stdin.on("data", onInput);
-  process.stdout.on("resize", onResize);
 
   return () => {
     process.stdin.off("data", onInput);
-    process.stdout.off("resize", onResize);
     process.stdin.pause();
+    proc.stdin?.end();
 
     for (const [signal, handler] of signalHandlers) {
       process.off(signal, handler);
@@ -282,9 +279,108 @@ function setupTerminalHandlers(proc: Bun.Subprocess) {
     if (!proc.killed && proc.exitCode === null) {
       proc.kill("SIGTERM");
     }
-
-    terminal.close();
   };
+}
+
+function normalizeCommandForEnvironment(command: string[]) {
+  const normalized = stripElideLineArgs(command);
+  const expanded = expandBunScriptIfNeeded(normalized);
+  return expanded ?? normalized;
+}
+
+async function pumpProcessOutput(
+  stream: ReadableStream<Uint8Array> | null,
+  onChunk: (chunk: Uint8Array) => void
+) {
+  if (!stream) {
+    return;
+  }
+
+  const reader = stream.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value) {
+        onChunk(value);
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function stripElideLineArgs(command: string[]) {
+  const normalized: string[] = [];
+  for (let i = 0; i < command.length; i += 1) {
+    const arg = command[i];
+    if (arg.startsWith("--elide-lines=")) {
+      continue;
+    }
+    if (arg === "--elide-lines") {
+      i += 1;
+      continue;
+    }
+    normalized.push(arg);
+  }
+  return normalized;
+}
+
+function expandBunScriptIfNeeded(command: string[]) {
+  if (command.length !== 2 || command[0] !== "bun") {
+    return null;
+  }
+
+  const scriptName = command[1];
+  if (scriptName.startsWith("-")) {
+    return null;
+  }
+
+  const packageJsonPath = findNearestPackageJson(process.cwd());
+  if (!packageJsonPath) {
+    return null;
+  }
+
+  const packageJson = JSON.parse(
+    readFileSync(packageJsonPath, "utf8")
+  ) as { scripts?: Record<string, string> };
+  const script = packageJson.scripts?.[scriptName];
+  if (!script || !script.includes("--elide-lines")) {
+    return null;
+  }
+
+  const sanitized = sanitizeScriptCommand(script);
+  if (!sanitized) {
+    return null;
+  }
+
+  return ["sh", "-lc", sanitized];
+}
+
+function sanitizeScriptCommand(script: string) {
+  return script
+    .replace(/(^|\s)--elide-lines=\S+(?=\s|$)/g, " ")
+    .replace(/(^|\s)--elide-lines\s+\S+(?=\s|$)/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function findNearestPackageJson(startDir: string) {
+  let current = startDir;
+  while (true) {
+    const candidate = join(current, "package.json");
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+
+    const parent = dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
 }
 
 async function closeStreams(


### PR DESCRIPTION
## Summary
- normalize wrapped commands to strip Bun's `--elide-lines` flag in non-TTY runs, including `bun <script>` cases where the flag is defined inside `package.json` scripts
- switch CLI process wiring to piped stdio forwarding so output capture remains reliable without Bun terminal mode
- add a regression test that reproduces `openlogs bun dev:desktop` with an embedded `--elide-lines=0` script and verifies successful execution

## Test plan
- [x] `bun test packages/ol/src/cli.test.ts`
- [x] `bun /Users/air15/Documents/GitHub/openlogs/packages/ol/src/cli.ts bun dev:desktop`

Closes #2
Issue: https://github.com/charlietlamb/openlogs/issues/2

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes non-TTY execution of `bun` scripts in `openlogs` by stripping `--elide-lines` (including when defined in `package.json` scripts) and switching to piped stdio to keep logs reliable. Closes #2.

- **Bug Fixes**
  - Remove `--elide-lines` from commands and expand `bun <script>` via nearest `package.json`, sanitizing embedded flags.
  - Replace PTY mode with piped stdin/stdout/stderr, forwarding input and signals and streaming output consistently.
  - Add regression test for `openlogs bun dev:desktop` with an embedded `--elide-lines=0`.

<sup>Written for commit ae04cfd75c9af400786df2d2b0f2cc9f882caa0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

