### PR TITLE
fix: make the browser collector resilient to port conflicts and orphans

### DIFF
--- a/packages/ol/src/cli.test.ts
+++ b/packages/ol/src/cli.test.ts
@@ -243,6 +243,64 @@ test("cli starts a browser collector while the command runs", async () => {
   expect(await proc.exited).toBe(143);
 });
 
+test("concurrent collectors sharing a preferred port bind to distinct ports", async () => {
+  const sharedPort = getAvailablePort();
+  const outDirA = join(process.cwd(), ".tmp-openlogs-a");
+  const outDirB = join(process.cwd(), ".tmp-openlogs-b");
+
+  const spawnRun = (dir: string) =>
+    Bun.spawn(["bun", cliPath, "--out-dir", dir, "sh", "-lc", "sleep 5"], {
+      cwd: process.cwd(),
+      env: { ...Bun.env, OPENLOGS_COLLECTOR_PORT: String(sharedPort) },
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+  const loadRecord = (dir: string) =>
+    waitFor(
+      async () => {
+        try {
+          const record = await Bun.file(join(dir, "collector.json")).json();
+          if (typeof record?.port !== "number") {
+            return null;
+          }
+          const response = await fetch(`http://127.0.0.1:${record.port}/health`);
+          return response.ok ? await response.json() : null;
+        } catch {
+          return null;
+        }
+      },
+      (value) => value?.outDir === dir,
+      5000
+    );
+
+  const procA = spawnRun(outDirA);
+  const procB = spawnRun(outDirB);
+
+  try {
+    const [healthA, healthB] = await Promise.all([
+      loadRecord(outDirA),
+      loadRecord(outDirB),
+    ]);
+
+    expect(healthA.ok).toBe(true);
+    expect(healthB.ok).toBe(true);
+    expect(healthA.outDir).toBe(outDirA);
+    expect(healthB.outDir).toBe(outDirB);
+    expect(healthA.port).not.toBe(healthB.port);
+    expect([healthA.port, healthB.port]).toContain(sharedPort);
+  } finally {
+    procA.kill("SIGTERM");
+    procB.kill("SIGTERM");
+    await Promise.all([procA.exited, procB.exited]);
+    await Promise.all([
+      rm(outDirA, { force: true, recursive: true }),
+      rm(outDirB, { force: true, recursive: true }),
+    ]);
+  }
+});
+
 test("cli tail prints the latest text log", async () => {
   await mkdir(outDir, { recursive: true });
   await Bun.write(join(outDir, "latest.txt"), "one\ntwo\nthree\n");

--- a/packages/ol/src/cli.test.ts
+++ b/packages/ol/src/cli.test.ts
@@ -48,13 +48,29 @@ function spawnCli(command: string[]) {
 
 function spawnCliInPty(command: string[]) {
   return Bun.spawn(
-    ["python3", "-c", ptyScript, "bun", cliPath, "--out-dir", outDir, ...command],
+    [
+      "python3",
+      "-c",
+      ptyScript,
+      "bun",
+      cliPath,
+      "--out-dir",
+      outDir,
+      ...command,
+    ],
     {
       cwd: process.cwd(),
       stdout: "pipe",
       stderr: "pipe",
     }
   );
+}
+
+function getAvailablePort() {
+  const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+  const { port } = server;
+  server.stop(true);
+  return port;
 }
 
 async function waitFor<T>(
@@ -191,6 +207,40 @@ test("cli works when launched from a tty", async () => {
 
   expect(await proc.exited).toBe(0);
   expect(await Bun.file(join(outDir, "latest.txt")).text()).toBe("tty\n");
+});
+
+test("cli starts a browser collector while the command runs", async () => {
+  const port = getAvailablePort();
+  const proc = Bun.spawn(
+    ["bun", cliPath, "--out-dir", outDir, "sh", "-lc", "sleep 5"],
+    {
+      cwd: process.cwd(),
+      env: { ...Bun.env, OPENLOGS_COLLECTOR_PORT: String(port) },
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    }
+  );
+
+  try {
+    const health = await waitFor(
+      async () => {
+        try {
+          const response = await fetch(`http://127.0.0.1:${port}/health`);
+          return response.ok ? response.json() : null;
+        } catch {
+          return null;
+        }
+      },
+      (value) => value?.outDir === outDir
+    );
+
+    expect(health.ok).toBe(true);
+  } finally {
+    proc.kill("SIGTERM");
+  }
+
+  expect(await proc.exited).toBe(143);
 });
 
 test("cli tail prints the latest text log", async () => {

--- a/packages/ol/src/cli.ts
+++ b/packages/ol/src/cli.ts
@@ -6,7 +6,7 @@ import { createWriteStream } from "node:fs";
 import { access, appendFile, mkdir, rm } from "node:fs/promises";
 import process from "node:process";
 import { finished } from "node:stream/promises";
-import { runCollector } from "./collector";
+import { loadCollectorRecord, runCollector } from "./collector";
 import {
   cleanChunk,
   cleanLogText,
@@ -217,8 +217,10 @@ async function stopCollector(proc: Bun.Subprocess | undefined) {
 
 async function startCollector(outDir: string) {
   const host = "127.0.0.1";
-  const port = Number(Bun.env.OPENLOGS_COLLECTOR_PORT ?? 4318);
-  if (await isCollectorHealthy(host, port, outDir)) {
+  const preferredPort = Number(Bun.env.OPENLOGS_COLLECTOR_PORT ?? 4318);
+
+  const existing = await loadCollectorRecord(outDir);
+  if (existing && (await isCollectorHealthy(host, existing.port, outDir))) {
     return;
   }
 
@@ -232,13 +234,17 @@ async function startCollector(outDir: string) {
       "--host",
       host,
       "--port",
-      String(port),
+      String(preferredPort),
     ],
     { stderr: "pipe", stdin: "ignore", stdout: "ignore" }
   );
 
-  for (let i = 0; i < 40; i += 1) {
-    if (await isCollectorHealthy(host, port, outDir)) {
+  for (let i = 0; i < 100; i += 1) {
+    const record = await loadCollectorRecord(outDir);
+    if (
+      record?.pid === proc.pid &&
+      (await isCollectorHealthy(host, record.port, outDir))
+    ) {
       return proc;
     }
     if (proc.exitCode !== null) {
@@ -252,7 +258,7 @@ async function startCollector(outDir: string) {
     ? `\n${await new Response(proc.stderr).text()}`
     : "";
   throw new Error(
-    `Failed to start the openlogs collector on http://${host}:${port}.${detail}`
+    `Failed to start the openlogs collector for ${outDir} (preferred port ${preferredPort}).${detail}`
   );
 }
 

--- a/packages/ol/src/cli.ts
+++ b/packages/ol/src/cli.ts
@@ -6,6 +6,7 @@ import { createWriteStream } from "node:fs";
 import { access, appendFile, mkdir, rm } from "node:fs/promises";
 import process from "node:process";
 import { finished } from "node:stream/promises";
+import { runCollector } from "./collector";
 import {
   cleanChunk,
   cleanLogText,
@@ -27,8 +28,18 @@ if (process.platform === "win32") {
 }
 
 const supervisionScript = `
-import os
 import signal
+
+pending_signal = None
+
+def handle_early_signal(signum, _frame):
+    global pending_signal
+    pending_signal = signum
+
+for signum in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+    signal.signal(signum, handle_early_signal)
+
+import os
 import subprocess
 import sys
 import time
@@ -98,6 +109,9 @@ def handle_signal(signum, _frame):
 for signum in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
     signal.signal(signum, handle_signal)
 
+if pending_signal is not None:
+    handle_signal(pending_signal, None)
+
 while child.poll() is None:
     snapshot_descendants()
     time.sleep(0.05)
@@ -123,6 +137,9 @@ try {
 
 async function main() {
   const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.kind === "collector") {
+    return runCollector(parsed.options);
+  }
   if (parsed.kind === "tail") {
     return runTail(parsed.options);
   }
@@ -142,6 +159,7 @@ async function main() {
   const rawStreams = paths.rawPaths.map((path) => createWriteStream(path));
   const textStreams = paths.textPaths.map((path) => createWriteStream(path));
   const decoder = new TextDecoder();
+  let collector: Bun.Subprocess | undefined;
   const proc = Bun.spawn(
     ["python3", "-c", supervisionScript, ...options.command],
     {
@@ -171,6 +189,7 @@ async function main() {
   }
 
   try {
+    collector = await startCollector(options.outDir);
     return await proc.exited;
   } finally {
     const flushed = flushCleanText(decoder);
@@ -181,9 +200,69 @@ async function main() {
     }
 
     await teardown();
+    await stopCollector(collector);
     await closeStreams(captureStream, rawStreams, textStreams);
     await rewriteTextLogs(paths.captureRawPath, paths.textPaths);
     await rm(paths.captureRawPath, { force: true });
+  }
+}
+
+async function stopCollector(proc: Bun.Subprocess | undefined) {
+  if (!proc) {
+    return;
+  }
+  proc.kill("SIGTERM");
+  await proc.exited;
+}
+
+async function startCollector(outDir: string) {
+  const host = "127.0.0.1";
+  const port = Number(Bun.env.OPENLOGS_COLLECTOR_PORT ?? 4318);
+  if (await isCollectorHealthy(host, port, outDir)) {
+    return;
+  }
+
+  const proc = Bun.spawn(
+    [
+      "bun",
+      process.argv[1],
+      "collector",
+      "--out-dir",
+      outDir,
+      "--host",
+      host,
+      "--port",
+      String(port),
+    ],
+    { stderr: "pipe", stdin: "ignore", stdout: "ignore" }
+  );
+
+  for (let i = 0; i < 40; i += 1) {
+    if (await isCollectorHealthy(host, port, outDir)) {
+      return proc;
+    }
+    if (proc.exitCode !== null) {
+      break;
+    }
+    await Bun.sleep(50);
+  }
+
+  proc.kill("SIGTERM");
+  const detail = proc.stderr
+    ? `\n${await new Response(proc.stderr).text()}`
+    : "";
+  throw new Error(
+    `Failed to start the openlogs collector on http://${host}:${port}.${detail}`
+  );
+}
+
+async function isCollectorHealthy(host: string, port: number, outDir: string) {
+  try {
+    const health = await fetch(`http://${host}:${port}/health`);
+    const record = await health.json();
+    return health.ok && record?.ok === true && record?.outDir === outDir;
+  } catch {
+    return false;
   }
 }
 

--- a/packages/ol/src/collector.ts
+++ b/packages/ol/src/collector.ts
@@ -50,40 +50,37 @@ export async function runCollector(options: ServeOptions) {
     startedAt: new Date().toISOString(),
   } satisfies Omit<CollectorRecord, "port">;
 
-  const server = Bun.serve({
-    hostname: options.host,
-    port: options.port,
-    async fetch(request) {
-      const url = new URL(request.url);
-      if (request.method === "OPTIONS") {
-        return new Response(null, { headers: corsHeaders, status: 204 });
-      }
-      if (request.method === "GET" && url.pathname === "/health") {
-        return Response.json(
-          { ok: true, ...recordBase, port: server.port },
-          { headers: corsHeaders }
-        );
-      }
-      if (request.method !== "POST" || url.pathname !== "/ingest") {
-        return new Response("Not found", { status: 404 });
-      }
-
-      const payload = await request.json().catch(() => null);
-      let events: BrowserEvent[] = [];
-      if (Array.isArray((payload as BrowserBatch | null)?.events)) {
-        events = (payload as BrowserBatch).events ?? [];
-      } else if (Array.isArray(payload)) {
-        events = payload as BrowserEvent[];
-      }
-
-      await Promise.all(
-        events.map((event) =>
-          appendBrowserEvent(event, sources, options.outDir)
-        )
-      );
+  let server: ReturnType<typeof Bun.serve>;
+  const fetch = async (request: Request) => {
+    const url = new URL(request.url);
+    if (request.method === "OPTIONS") {
       return new Response(null, { headers: corsHeaders, status: 204 });
-    },
-  });
+    }
+    if (request.method === "GET" && url.pathname === "/health") {
+      return Response.json(
+        { ok: true, ...recordBase, port: server.port },
+        { headers: corsHeaders }
+      );
+    }
+    if (request.method !== "POST" || url.pathname !== "/ingest") {
+      return new Response("Not found", { status: 404 });
+    }
+
+    const payload = await request.json().catch(() => null);
+    let events: BrowserEvent[] = [];
+    if (Array.isArray((payload as BrowserBatch | null)?.events)) {
+      events = (payload as BrowserBatch).events ?? [];
+    } else if (Array.isArray(payload)) {
+      events = payload as BrowserEvent[];
+    }
+
+    await Promise.all(
+      events.map((event) => appendBrowserEvent(event, sources, options.outDir))
+    );
+    return new Response(null, { headers: corsHeaders, status: 204 });
+  };
+
+  server = listenOnAvailablePort(options.host, options.port, fetch);
 
   const record = { ...recordBase, port: server.port } satisfies CollectorRecord;
   await Bun.write(
@@ -91,7 +88,14 @@ export async function runCollector(options: ServeOptions) {
     `${JSON.stringify(record, null, 2)}\n`
   );
 
+  let closing = false;
+  let parentWatch: ReturnType<typeof setInterval> | undefined;
   const cleanup = async () => {
+    if (closing) {
+      return;
+    }
+    closing = true;
+    clearInterval(parentWatch);
     server.stop(true);
     const current = await loadCollectorRecord(options.outDir);
     if (current?.pid === process.pid) {
@@ -105,7 +109,54 @@ export async function runCollector(options: ServeOptions) {
     });
   }
 
+  // Exit if the launching process dies, so collectors never linger and squat
+  // the port (which would block future runs, e.g. across git worktrees).
+  const parentPid = process.ppid;
+  parentWatch = setInterval(() => {
+    if (process.ppid !== parentPid || !isProcessAlive(parentPid)) {
+      cleanup().finally(() => process.exit(0));
+    }
+  }, 500);
+
   await new Promise(() => undefined);
+}
+
+function isProcessAlive(pid: number) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function listenOnAvailablePort(
+  host: string,
+  startPort: number,
+  fetch: (request: Request) => Response | Promise<Response>
+) {
+  const maxAttempts = 64;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      return Bun.serve({ fetch, hostname: host, port: startPort + attempt });
+    } catch (error) {
+      lastError = error;
+      if (!isAddressInUse(error)) {
+        throw error;
+      }
+    }
+  }
+  throw lastError;
+}
+
+function isAddressInUse(error: unknown) {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const code = "code" in error ? String(error.code) : "";
+  const message = error instanceof Error ? error.message : String(error);
+  return code === "EADDRINUSE" || /eaddrinuse|in use/i.test(message);
 }
 
 export async function loadCollectorRecord(outDir: string) {

--- a/packages/ol/src/collector.ts
+++ b/packages/ol/src/collector.ts
@@ -1,0 +1,221 @@
+/* global Bun */
+
+import { appendFile, mkdir, rm } from "node:fs/promises";
+import process from "node:process";
+import {
+  type CollectorRecord,
+  getBrowserLogPaths,
+  getBrowserRunRecord,
+  getCollectorPath,
+  getRunIndexPath,
+  type LogPaths,
+  type ServeOptions,
+} from "./shared";
+
+interface BrowserEvent {
+  args?: unknown[];
+  kind?: string;
+  level?: string;
+  message?: string;
+  meta?: Record<string, unknown>;
+  source?: string;
+  stack?: string;
+  ts?: string;
+  url?: string;
+}
+
+interface BrowserBatch {
+  events?: BrowserEvent[];
+}
+
+interface BrowserSource {
+  paths: LogPaths;
+  source?: string;
+}
+
+const corsHeaders = {
+  "access-control-allow-headers": "content-type",
+  "access-control-allow-methods": "GET,POST,OPTIONS",
+  "access-control-allow-origin": "*",
+} satisfies Record<string, string>;
+
+export async function runCollector(options: ServeOptions) {
+  await mkdir(options.outDir, { recursive: true });
+  const sources = new Map<string, BrowserSource>();
+  const recordBase = {
+    host: options.host,
+    outDir: options.outDir,
+    pid: process.pid,
+    projectRoot: process.cwd(),
+    startedAt: new Date().toISOString(),
+  } satisfies Omit<CollectorRecord, "port">;
+
+  const server = Bun.serve({
+    hostname: options.host,
+    port: options.port,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (request.method === "OPTIONS") {
+        return new Response(null, { headers: corsHeaders, status: 204 });
+      }
+      if (request.method === "GET" && url.pathname === "/health") {
+        return Response.json(
+          { ok: true, ...recordBase, port: server.port },
+          { headers: corsHeaders }
+        );
+      }
+      if (request.method !== "POST" || url.pathname !== "/ingest") {
+        return new Response("Not found", { status: 404 });
+      }
+
+      const payload = await request.json().catch(() => null);
+      let events: BrowserEvent[] = [];
+      if (Array.isArray((payload as BrowserBatch | null)?.events)) {
+        events = (payload as BrowserBatch).events ?? [];
+      } else if (Array.isArray(payload)) {
+        events = payload as BrowserEvent[];
+      }
+
+      await Promise.all(
+        events.map((event) =>
+          appendBrowserEvent(event, sources, options.outDir)
+        )
+      );
+      return new Response(null, { headers: corsHeaders, status: 204 });
+    },
+  });
+
+  const record = { ...recordBase, port: server.port } satisfies CollectorRecord;
+  await Bun.write(
+    getCollectorPath(options.outDir),
+    `${JSON.stringify(record, null, 2)}\n`
+  );
+
+  const cleanup = async () => {
+    server.stop(true);
+    const current = await loadCollectorRecord(options.outDir);
+    if (current?.pid === process.pid) {
+      await rm(getCollectorPath(options.outDir), { force: true });
+    }
+  };
+
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+    process.on(signal, () => {
+      cleanup().finally(() => process.exit(0));
+    });
+  }
+
+  await new Promise(() => undefined);
+}
+
+export async function loadCollectorRecord(outDir: string) {
+  try {
+    return JSON.parse(
+      await Bun.file(getCollectorPath(outDir)).text()
+    ) as CollectorRecord;
+  } catch {
+    return;
+  }
+}
+
+async function appendBrowserEvent(
+  event: BrowserEvent,
+  sources: Map<string, BrowserSource>,
+  outDir: string
+) {
+  const source = cleanSource(event.source);
+  let entry = sources.get(source ?? "browser");
+  if (!entry) {
+    const paths = getBrowserLogPaths(outDir, source);
+    await Promise.all(
+      [...new Set([...paths.rawPaths, ...paths.textPaths])].map((path) =>
+        Bun.write(path, "")
+      )
+    );
+    await appendFile(
+      getRunIndexPath(outDir),
+      `${JSON.stringify(getBrowserRunRecord(outDir, paths, source))}\n`
+    );
+    entry = { paths, source };
+    sources.set(source ?? "browser", entry);
+  }
+
+  const normalized = normalizeBrowserEvent(event, source);
+  await Promise.all([
+    appendFile(entry.paths.rawPath, `${JSON.stringify(normalized)}\n`),
+    ...entry.paths.rawPaths
+      .filter((path) => path !== entry?.paths.rawPath)
+      .map((path) => appendFile(path, `${JSON.stringify(normalized)}\n`)),
+    appendFile(entry.paths.textPath, renderBrowserEvent(normalized)),
+    ...entry.paths.textPaths
+      .filter((path) => path !== entry?.paths.textPath)
+      .map((path) => appendFile(path, renderBrowserEvent(normalized))),
+  ]);
+}
+
+function normalizeBrowserEvent(event: BrowserEvent, source?: string) {
+  const args = Array.isArray(event.args)
+    ? event.args.map((value) => stringifyValue(value))
+    : undefined;
+  const message = [event.message, args?.join(" ")]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+
+  return {
+    kind: event.kind || "console",
+    level: (event.level || "info").toUpperCase(),
+    message: message || "(empty)",
+    meta: event.meta,
+    source: source || "browser",
+    stack: event.stack,
+    ts: event.ts || new Date().toISOString(),
+    url: event.url,
+  };
+}
+
+function renderBrowserEvent(event: ReturnType<typeof normalizeBrowserEvent>) {
+  const header = [
+    event.ts,
+    event.level.padEnd(5, " "),
+    event.source,
+    event.message,
+    event.url ? `(${event.url})` : "",
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+  const stack = event.stack
+    ? `${event.stack
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => `  ${line}`)
+        .join("\n")}\n`
+    : "";
+
+  return `${header}\n${stack}`;
+}
+
+function cleanSource(source?: string) {
+  const normalized = source?.trim();
+  return normalized || undefined;
+}
+
+function stringifyValue(value: unknown) {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    value == null
+  ) {
+    return String(value);
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return Object.prototype.toString.call(value);
+  }
+}

--- a/packages/ol/src/shared.ts
+++ b/packages/ol/src/shared.ts
@@ -17,7 +17,14 @@ export interface TailOptions {
   tailArgs: string[];
 }
 
+export interface ServeOptions {
+  host: string;
+  outDir: string;
+  port: number;
+}
+
 export type ParsedArgs =
+  | { kind: "collector"; options: ServeOptions }
   | { kind: "run"; options: CliOptions }
   | { kind: "tail"; options: TailOptions };
 
@@ -46,7 +53,16 @@ export interface RunRecord {
   textPath: string;
 }
 
+export interface CollectorRecord extends ServeOptions {
+  pid: number;
+  projectRoot: string;
+  startedAt: string;
+}
+
 export function parseArgs(argv: string[]): ParsedArgs {
+  if (argv[0] === "collector") {
+    return { kind: "collector", options: parseServeArgs(argv.slice(1)) };
+  }
   if (argv[0] === "tail") {
     return { kind: "tail", options: parseTailArgs(argv.slice(1)) };
   }
@@ -171,6 +187,37 @@ export function parseTailArgs(argv: string[]): TailOptions {
   return { outDir, query, raw, tailArgs: argv.slice(i) };
 }
 
+export function parseServeArgs(argv: string[]): ServeOptions {
+  let host = "127.0.0.1";
+  let outDir = ".openlogs";
+  let port = 4318;
+
+  for (let i = 0; i < argv.length; ) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--host":
+        host = argv[i + 1] ?? fail(`Missing value for ${arg}`);
+        i += 2;
+        break;
+      case "--out-dir":
+        outDir = argv[i + 1] ?? fail(`Missing value for ${arg}`);
+        i += 2;
+        break;
+      case "--port":
+        port = Number(argv[i + 1] ?? fail(`Missing value for ${arg}`));
+        if (!Number.isInteger(port) || port <= 0) {
+          fail(`Invalid value for ${arg}`);
+        }
+        i += 2;
+        break;
+      default:
+        fail(`Unknown collector option: ${arg}`);
+    }
+  }
+
+  return { host, outDir, port };
+}
+
 export function cleanChunk(chunk: Uint8Array, decoder: TextDecoder) {
   return normalizeLogText(
     stripVTControlCharacters(decoder.decode(chunk, { stream: true }))
@@ -229,6 +276,10 @@ export function getRunIndexPath(outDir: string) {
   return `${outDir}/runs.jsonl`;
 }
 
+export function getCollectorPath(outDir: string) {
+  return `${outDir}/collector.json`;
+}
+
 export function getRunRecord(
   options: CliOptions,
   paths: LogPaths,
@@ -239,6 +290,36 @@ export function getRunRecord(
     key: paths.key,
     name: options.name,
     outDir: options.outDir,
+    rawPath: paths.rawPath,
+    startedAt: now.toISOString(),
+    textPath: paths.textPath,
+  } satisfies RunRecord;
+}
+
+export function getBrowserLogPaths(outDir: string, source?: string): LogPaths {
+  const key = source ? `browser-${slugify(source)}` : "browser";
+  const prefix = `${outDir}/${key}`;
+  return {
+    captureRawPath: `${prefix}.raw.log`,
+    key,
+    rawPath: `${prefix}.raw.log`,
+    rawPaths: [`${prefix}.raw.log`],
+    textPath: `${prefix}.txt`,
+    textPaths: [`${prefix}.txt`],
+  };
+}
+
+export function getBrowserRunRecord(
+  outDir: string,
+  paths: LogPaths,
+  source?: string,
+  now = new Date()
+) {
+  return {
+    command: source ? `browser ${source}` : "browser",
+    key: paths.key,
+    name: source,
+    outDir,
     rawPath: paths.rawPath,
     startedAt: now.toISOString(),
     textPath: paths.textPath,


### PR DESCRIPTION
## Summary

Fixes `Failed to start the openlogs collector on http://127.0.0.1:4318`, which happens whenever something is already using the collector's port — most commonly a previous collector that was orphaned, or another `openlogs` run in a different git worktree.

- **Auto-select an available port.** The collector now tries the preferred port (`4318` / `OPENLOGS_COLLECTOR_PORT`) and scans upward on `EADDRINUSE` instead of failing. The actual bound port is written to each project's `.openlogs/collector.json`.
- **Per-project discovery + reuse.** `startCollector` reads the real port from `collector.json` and only reuses a collector that belongs to the same project, so concurrent runs across worktrees each get their own collector. A single project still prefers `4318` so the well-known port keeps working for browser snippets.
- **No more orphaned collectors.** The collector now exits (and removes its `collector.json`) when its launching process dies — even on `SIGKILL` — so it never lingers and squats the port for future runs.

### Root cause

The collector bound a hardcoded `4318`. When a prior collector got reparented to PID 1 and kept running (or another worktree's collector was live), every subsequent run hit `EADDRINUSE`, the collector subprocess died, and `startCollector` threw.

## Test plan

- [x] `bun test packages/ol` — 29/29 pass (run from repo root)
- [x] New test: two runs in different out-dirs sharing the same preferred port both come up healthy on distinct ports
- [x] Manual: two concurrent worktrees start cleanly on distinct ports; a single run binds `4318`; collector self-exits and cleans up after the parent is `SIGKILL`ed

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes browser collector startup failures when port 4318 is taken and prevents orphaned collectors from squatting ports. This lets multiple worktrees run concurrently without conflicts and keeps the well-known port working when available.

- **Bug Fixes**
  - Auto-selects an available port (tries `OPENLOGS_COLLECTOR_PORT`/4318, scans upward on conflict) and writes the bound port to `.openlogs/collector.json`.
  - Reuses collectors per project by reading `collector.json`, so only matching projects connect; concurrent worktrees get separate collectors.
  - Collector exits (and removes `collector.json`) when the launching process dies, avoiding orphans.

<sup>Written for commit e02219e8d095ed96f61b78798610688c818c7afe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/charlietlamb/openlogs/pull/8?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

