### PR TITLE
Fix landing page theme flash

### DIFF
--- a/apps/web/components/logs/index.tsx
+++ b/apps/web/components/logs/index.tsx
@@ -5,15 +5,18 @@ import { cn } from "@/lib/cn";
 import { buildLogs } from "./log-data";
 import { TerminalLayer } from "./terminal-layer";
 
+const INITIAL_NOW = Date.UTC(2026, 0, 1, 12, 0, 0);
+
 interface LogsPaneProps {
   className?: string;
 }
 
 export function LogsPane({ className }: LogsPaneProps) {
   const [logs] = useState(() => buildLogs());
-  const [now, setNow] = useState(() => Date.now());
+  const [now, setNow] = useState(INITIAL_NOW);
 
   useEffect(() => {
+    setNow(Date.now());
     const interval = window.setInterval(() => setNow(Date.now()), 250);
     return () => window.clearInterval(interval);
   }, []);

--- a/apps/web/components/nav-header.tsx
+++ b/apps/web/components/nav-header.tsx
@@ -2,11 +2,17 @@
 
 import { MoonIcon, SunIcon, TerminalIcon } from "@phosphor-icons/react";
 import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
 import { GITHUB_URL } from "@/lib/constants";
 import { GitHubIcon } from "./icons/github-icon";
 
 export function NavHeader() {
   const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   return (
     <nav className="flex items-center gap-4 border-border border-b px-6 py-3">
@@ -40,7 +46,7 @@ export function NavHeader() {
           onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
           type="button"
         >
-          {resolvedTheme === "dark" ? (
+          {mounted && resolvedTheme === "dark" ? (
             <SunIcon className="size-4" weight="regular" />
           ) : (
             <MoonIcon className="size-4" weight="regular" />


### PR DESCRIPTION
hey, I opened the landing page and it was doing this quick flash from light mode into the default dark theme.

thought it was just a theme setup thing at first, but turns out it was actually a hydration issue. React was re-rendering part of the page on the client because the server output didn’t match the first client render.

The main mismatches were:

- `NavHeader` rendering a different theme icon between server/client.
- `LogsPane` using `Date.now()` on the initial render, so the log timestamps were always different during hydration.

Fixed it by making the first render stable, then letting the client-only stuff update after mount.

smol note: love light mode, so imo it’d be nice if the site respected the system theme instead of forcing dark by default. I left that as-is though since it seems intentional.. say the word and i would update it!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix theme flash on the landing page by eliminating server/client hydration mismatches. The first render is now stable; client-only values update after mount to prevent flicker.

- **Bug Fixes**
  - NavHeader: render theme icon only after mount to avoid a pre-hydration icon mismatch.
  - LogsPane: start with a fixed timestamp, then switch to Date.now() in an effect to prevent hydration-time differences.

<sup>Written for commit f63142bad57ad4cbfb9af4900c48d8e0729e213f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/charlietlamb/openlogs/pull/9?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

